### PR TITLE
feat: add yoast seo compatibility

### DIFF
--- a/src/server/utils/dataLoader.ts
+++ b/src/server/utils/dataLoader.ts
@@ -73,7 +73,7 @@ export const loadPreviewDocumentProps = async (
     throw new Error('Missing NEOS_BASE_URL environment variable');
   }
 
-  const contextPath = searchParams['node[__contextNodePath]'];
+  const contextPath = searchParams['node[__contextNodePath]'] ?? searchParams['node'];
   if (typeof contextPath !== 'string') {
     throw new Error('Missing context path query parameter');
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -7,6 +7,14 @@ export const withZebra = (nextConfig: NextConfig): NextConfig => {
       const baseUrl = process.env.NEOS_BASE_URL ?? '';
       const neosRewrites = [
         {
+          source: '/neosyoastseo/data/:path*',
+          destination: baseUrl + '/neosyoastseo/data/:path*',
+        },
+        {
+          source: '/neosyoastseo/page/renderPreviewPage',
+          destination: '/neos/preview',
+        },
+        {
           source: '/neos/:path*',
           destination: baseUrl + '/neos/:path*',
         },


### PR DESCRIPTION
The [Yoast SEO for Neos package](https://github.com/Yoast/Yoast-SEO-for-Neos) needs to be able to render the preview page in order to analyse the SEO score.
It also adds a couple of routes to retrieve its configuration.